### PR TITLE
CI: Use dtolnay/rust-toolchain for Rust.

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,9 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Action actions-rs/toolchain seems to be dead, see: actions-rs/toolchain#216

See: https://github.com/dtolnay/rust-toolchain
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
